### PR TITLE
Rubygems Not always Included

### DIFF
--- a/bin/newrelic_beanstalkd
+++ b/bin/newrelic_beanstalkd
@@ -1,5 +1,6 @@
 #! /usr/bin/env ruby
 
+require 'rubygems'
 require 'newrelic_plugin'
 require 'beaneater'
 


### PR DESCRIPTION
In some cases the load path is not always set with rubygems. Adding a require fixes the issue at the begining on the script.

Signed-off-by: Joshua Lawrence lawrence.joshua@gmail.com
